### PR TITLE
Fix for GO-2025-4155 and GO-2025-4175

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yottta/go-core
 
-go 1.25.4
+go 1.25.5
 
 require (
 	github.com/go-chi/chi/v5 v5.2.3


### PR DESCRIPTION
Update go version from 1.25.4 to 1.25.5 to fix GO-2025-4175 and GO-2025-4155

Resolves #12 #13
